### PR TITLE
add Mexc Api with tests

### DIFF
--- a/src/main/java/com/example/notification/api/MexcService.java
+++ b/src/main/java/com/example/notification/api/MexcService.java
@@ -1,0 +1,38 @@
+package com.example.notification.api;
+
+import com.example.notification.dto.ApiResponse;
+import com.example.notification.bot.TelegramMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MexcService {
+
+    private final RestTemplate restTemplate;
+    private final String BASE_URL = "https://api.mexc.com";
+    private final String AVERAGE_PRICE_URL = "/api/v3/avgPrice?symbol=";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String getAvgPrice(String symbol) {
+        try {
+            String response = restTemplate.getForObject(BASE_URL + AVERAGE_PRICE_URL + symbol, String.class);
+
+            ApiResponse apiResponse = objectMapper.readValue(response, ApiResponse.class);
+            return apiResponse.getPrice();
+        } catch (JsonProcessingException e) {
+            log.error(TelegramMessage.ERROR_GET_AVERAGE_PRICE, e);
+            return TelegramMessage.ERROR_GET_AVERAGE_PRICE;
+        } catch (RestClientException e) {
+            log.error(TelegramMessage.API_SERVICE_UNAVAILABLE, e);
+            return TelegramMessage.API_SERVICE_UNAVAILABLE;
+        }
+    }
+}

--- a/src/main/java/com/example/notification/api/RestClientConfig.java
+++ b/src/main/java/com/example/notification/api/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.example.notification.api;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestTemplate createRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(10000);
+
+        restTemplate.setRequestFactory(requestFactory);
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/example/notification/bot/TelegramBotService.java
+++ b/src/main/java/com/example/notification/bot/TelegramBotService.java
@@ -1,5 +1,6 @@
 package com.example.notification.bot;
 
+import com.example.notification.api.MexcService;
 import com.example.notification.bot.config.TelegramBotConfig;
 import com.example.notification.model.entity.User;
 import com.example.notification.service.NotificationService;
@@ -21,6 +22,7 @@ public class TelegramBotService extends TelegramLongPollingBot {
     private static final String ETH = "/eth";
     private static final String LTC = "/ltc";
     private static final String DNX = "/dnx";
+    private static final String AVERAGE_PRICE_BTC = "BTCUSDT";
 
     @Autowired
     private TelegramBotConfig telegramBot;
@@ -31,6 +33,9 @@ public class TelegramBotService extends TelegramLongPollingBot {
     @Autowired
     private NotificationService notificationService;
 
+    @Autowired
+    private MexcService mexcService;
+
     @Override
     public void onUpdateReceived(Update update) {
         Message msg = update.getMessage();
@@ -40,10 +45,14 @@ public class TelegramBotService extends TelegramLongPollingBot {
         Long chatId = msg.getChatId();
 
         switch (message) {
-            case START -> {
-                String userName = update.getMessage().getChat().getUserName();
-                String firstName = update.getMessage().getChat().getFirstName();
+            case "/start" -> {
+                String userName = msg.getChat().getUserName();
+                String firstName = msg.getChat().getFirstName();
                 startCommand(chatId, userName, firstName);
+            }
+            case "/avgPrice" -> {
+                String avgPrice = mexcService.getAvgPrice(AVERAGE_PRICE_BTC);
+                sendMessage(chatId, String.format(TelegramMessage.GET_AVERAGE_PRICE, AVERAGE_PRICE_BTC, avgPrice));
             }
             default -> {
                 if (message.startsWith(BTC)) {

--- a/src/main/java/com/example/notification/bot/TelegramMessage.java
+++ b/src/main/java/com/example/notification/bot/TelegramMessage.java
@@ -27,4 +27,7 @@ public class TelegramMessage {
     public static final String EXCEEDING_MIN_THRESHOLD_VALUE = "Your minimum threshold value has been exceeded, current currency rate: %s";
     public static final String ERROR_OCCURRED_PLEASE_TRY_AGAIN_LATER = "An error occurred. Please try again later";
     public static final String ERROR_SETTING_LIMIT_PLEASE_CHECK_FORMAT = "An error occurred while setting the limit. Please check the command format.";
+    public static final String ERROR_GET_AVERAGE_PRICE = "Error when retrieving the price.";
+    public static final String GET_AVERAGE_PRICE = "Average price for the currency %s: %s";
+    public static final String API_SERVICE_UNAVAILABLE = "Failed to fetch data from Mexc API.";
 }

--- a/src/main/java/com/example/notification/dto/ApiResponse.java
+++ b/src/main/java/com/example/notification/dto/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.example.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponse {
+
+    private Long mins;
+    private String price;
+}

--- a/src/test/java/com/example/notification/api/MexcServiceJsonTest.java
+++ b/src/test/java/com/example/notification/api/MexcServiceJsonTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -13,6 +14,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
+@ActiveProfiles("test")
 public class MexcServiceJsonTest extends BaseTest {
 
     @MockBean

--- a/src/test/java/com/example/notification/api/MexcServiceJsonTest.java
+++ b/src/test/java/com/example/notification/api/MexcServiceJsonTest.java
@@ -1,0 +1,65 @@
+package com.example.notification.api;
+
+import com.example.notification.BaseTest;
+import com.example.notification.bot.TelegramMessage;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+public class MexcServiceJsonTest extends BaseTest {
+
+    @MockBean
+    private RestTemplate mockRestTemplate;
+
+    @Autowired
+    private MexcService mexcService;
+
+     /**
+     * Application: Verify handling of valid JSON response.
+     * What's being tested: The service correctly processes valid JSON data.
+     */
+    @Test
+    public void testGetAvgPriceValidJson() {
+        //Given
+        String invalidJson = "{ \"mins\": 5, \"price\": \"35082.566000000006\" }";
+        String symbol = "BTCUSDT";
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("https://api.mexc.com/api/v3/avgPrice")
+                .queryParam("symbol", symbol);
+        String uri = builder.toUriString();
+
+        //When
+        when(mockRestTemplate.getForObject(uri, String.class)).thenReturn(invalidJson);
+        String result = mexcService.getAvgPrice(symbol);
+
+        //Then
+        assertEquals(result, result);
+    }
+
+    /**
+     * Application: Verify handling of invalid JSON response.
+     * What's being tested: The service handles invalid JSON data and returns an error message.
+     */
+    @Test
+    public void testGetAvgPriceInvalidJson() {
+        //Given
+        String invalidJson = "{ \"mins\": 5, \"prce\": \"35082.566000000006\" }";
+        String symbol = "BTCUSDT";
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl("https://api.mexc.com/api/v3/avgPrice")
+                .queryParam("symbol", symbol);
+        String uri = builder.toUriString();
+
+        //When
+        when(mockRestTemplate.getForObject(uri, String.class)).thenReturn(invalidJson);
+        String result = mexcService.getAvgPrice(symbol);
+
+        //Then
+        assertEquals(TelegramMessage.ERROR_GET_AVERAGE_PRICE, result);
+    }
+}

--- a/src/test/java/com/example/notification/api/MexcServiceTest.java
+++ b/src/test/java/com/example/notification/api/MexcServiceTest.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Slf4j
+@ActiveProfiles("test")
 public class MexcServiceTest extends BaseTest {
 
     @Autowired

--- a/src/test/java/com/example/notification/api/MexcServiceTest.java
+++ b/src/test/java/com/example/notification/api/MexcServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.notification.api;
+
+import com.example.notification.BaseTest;
+import com.example.notification.bot.TelegramMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@Slf4j
+public class MexcServiceTest extends BaseTest {
+
+    @Autowired
+    private MexcService mexcService;
+
+    /**
+     * Application: Testing the correctness of retrieving the average price for the currency through the API.
+     * What's being tested: The API successfully retrieves the average price, and the obtained result is not null or empty.
+     */
+    @Test
+    public void testGetAvgPrice() {
+        //Given
+        String symbol = "BTCUSD";
+
+        //When
+        String price = mexcService.getAvgPrice(symbol);
+
+        //Then
+        assertNotNull(price);
+        assertFalse(price.isEmpty());
+    }
+
+    /**
+     * Application: Testing the handling of API errors when retrieving the average price for the currency.
+     * What's being tested: The system correctly handles API errors and returns the expected error message when trying to retrieve the average price for a specific currency.
+     */
+    @Test
+    public void testGetAvgPriceApiError() {
+        //Given
+        RestTemplate restTemplate = new RestTemplate() {
+            @Override
+            public <T> T getForObject(String url, Class<T> responseType, Object... uriVariables) throws RestClientException {
+                throw new RestClientException(TelegramMessage.API_SERVICE_UNAVAILABLE);
+            }
+        };
+        String symbol = "BTCUSDT";
+
+        //When
+        MexcService mexcServiceWithApiError = new MexcService(restTemplate);
+        String result = mexcServiceWithApiError.getAvgPrice(symbol);
+
+        //Then
+        assertEquals(TelegramMessage.API_SERVICE_UNAVAILABLE, result);
+    }
+}


### PR DESCRIPTION
I added
**MexcService** class get average cryptocurrency prices from the Mexc API.

 **RestClientConfig** creates a RestTemplate bean with a 10-second connection timeout. If the waiting time (timeout) of 10 seconds has elapsed, the request will be interrupted, and the client application will receive an error.
**ApiResponse** for parsing JSON API responses.

tests for the MexcService class.